### PR TITLE
chore(security): apply FTSC security baseline (non-js)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,20 @@
+# Non-JS repo: no husky/npm. Commit this to .githooks/pre-commit and run once:
+#   git config core.hooksPath .githooks && chmod +x .githooks/pre-commit
+
+# 1) Secret scan of staged changes
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "❌ gitleaks not installed. Install it: brew install gitleaks"
+  exit 1
+fi
+gitleaks git --staged --redact . || {
+  echo "❌ Commit blocked: gitleaks found a secret in staged changes."
+  exit 1
+}
+
+# 2) Block committing real .env / secret files (allow .example / .template)
+if git diff --cached --name-only \
+   | grep -E '(^|/)(\.env(\..*)?|\.dev\.vars|secrets?\..*)$' \
+   | grep -vE '\.(example|template)$' >/dev/null; then
+  echo "❌ Commit blocked: a secret file is staged. Unstage it: git reset HEAD <file>"
+  exit 1
+fi

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Default owners for everything in this repo.
+# CODEOWNERS auto-requests review; it only *enforces* once branch protection
+# is active (GitHub Team or higher). Update when ownership changes.
+* @jowenftsc

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  # If this is a Python repo with a requirements.txt / pyproject.toml, add:
+  # - package-ecosystem: "pip"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -8,6 +8,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   secrets-scan:
     uses: Fulcrum-Technology-Solutions/.github/.github/workflows/secrets-scan.yml@main

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -1,0 +1,13 @@
+name: Security Checks
+
+# Non-JS variant (no npm/build/lint/semgrep). Covers repos like firmware (C),
+# Splunk TAs, or scripts. Only secret scanning applies in CI; dependency and
+# SAST jobs are intentionally omitted because they target the JS toolchain.
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  secrets-scan:
+    uses: Fulcrum-Technology-Solutions/.github/.github/workflows/secrets-scan.yml@main

--- a/README.md
+++ b/README.md
@@ -474,6 +474,18 @@ We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guid
 - Follow the structure and metadata requirements in the `examples/` and `schemas/` directories.
 - Validate your files before submitting a pull request.
 
+### Security (local pre-commit)
+
+After cloning, run once to enable secret scanning on commit:
+
+```bash
+git config core.hooksPath .githooks
+chmod +x .githooks/pre-commit
+brew install gitleaks   # if not installed
+```
+
+CI runs TruffleHog via `.github/workflows/security-checks.yml` on push and pull request.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.


### PR DESCRIPTION
## Summary
- Add `.github/workflows/security-checks.yml` calling FTSC `secrets-scan` (TruffleHog)
- Add `.githooks/pre-commit` with gitleaks + `.env`/secret-file guard
- Add Dependabot for `github-actions` (no committed pip manifest)
- Add `.github/CODEOWNERS` (`@jowenftsc`)
- Document one-time local hook setup in README

## Test plan
- [x] Pre-commit hook executable and configured
- [ ] CI `Security Checks` / `secrets-scan` green on PR (alongside existing template workflows)

## Post-merge (GitHub settings)
On Team+ plan: enable branch protection on `main` with required check **Security Checks / secrets-scan**.

Made with [Cursor](https://cursor.com)