### PR TITLE
chore(deps): consolidate Dependabot GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    target-branch: "main"
   # If this is a Python repo with a requirements.txt / pyproject.toml, add:
   # - package-ecosystem: "pip"
   #   directory: "/"

--- a/.github/workflows/auto_version_and_index.yml
+++ b/.github/workflows/auto_version_and_index.yml
@@ -26,7 +26,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 2  # auto_version.py compares HEAD~1..HEAD
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -52,7 +52,7 @@ jobs:
       # Post-merge of this bot PR, this workflow may run again with only collection.json
       # changes; auto_version usually no-ops and there is no PR to open — no harm.
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: sync collection versions and TEMPLATES index"

--- a/.github/workflows/quarterly_major_release.yml
+++ b/.github/workflows/quarterly_major_release.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 2
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -78,7 +78,7 @@ jobs:
       
       - name: Create Release
         if: steps.check.outputs.changed == 'true'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: "v${{ steps.quarter.outputs.year }}-${{ steps.quarter.outputs.quarter }}"
           name: "Quarterly Major Release - ${{ steps.quarter.outputs.year }} ${{ steps.quarter.outputs.quarter }}"

--- a/.github/workflows/template_collection_release.yml
+++ b/.github/workflows/template_collection_release.yml
@@ -14,7 +14,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -133,7 +133,7 @@ jobs:
 
       - name: Create Release
         if: steps.products.outputs.products != '[]'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.reltag.outputs.tag }}
           name: "Template Updates - ${{ steps.reltag.outputs.tag }}"

--- a/.github/workflows/validate_templates.yml
+++ b/.github/workflows/validate_templates.yml
@@ -22,7 +22,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Set up Python
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
## Summary
Consolidates three open Dependabot PRs (#87–#89) into a single PR against `main`.

### GitHub Actions
- `actions/checkout` v3/v4 → **v7** (all workflows)
- `softprops/action-gh-release` v1 → **v3** (quarterly + collection release)
- `peter-evans/create-pull-request` v6 → **v8** (auto version/index)

### Dependabot routing
`target-branch: main` added to `.github/dependabot.yml` (this repo uses `main` only).

## Supersedes
Closes #87, #88, #89

## Test plan
- [ ] CI `secrets-scan` green on this PR
- [ ] `Validate Templates` workflow unaffected (checkout + setup-python@v6 already on main)

Made with [Cursor](https://cursor.com)