### PR TITLE
fix(ci): add least-privilege permissions to validate_templates workflow

### DIFF
--- a/.github/workflows/validate_templates.yml
+++ b/.github/workflows/validate_templates.yml
@@ -18,6 +18,9 @@ on:
       - 'templates/**/product.meta.yaml'
       - 'templates/**/collection.json'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Add explicit workflow-level `permissions` to satisfy CodeQL and apply least-privilege defaults for `GITHUB_TOKEN`:

```yaml
permissions:
  contents: read
```

The validate job only needs read access for checkout and running the validation script.

## Test plan
- [ ] `secrets-scan` and CodeQL green on this PR

Made with [Cursor](https://cursor.com)